### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Newsletter.php
+++ b/src/Newsletter.php
@@ -82,7 +82,7 @@ class Newsletter extends Plugin
         self::$plugin = $this;
 
         // Add in our Twig extensions
-        Craft::$app->view->twig->addExtension(new NewsletterTwigExtension());
+        Craft::$app->view->registerTwigExtension(new NewsletterTwigExtension());
 
         // Register our site routes
         Event::on(


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.